### PR TITLE
Update crypto library to prevent failing builds, make `Build` docs more verbose

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-crypto = "0.2"
+rust-crypto-wasm = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ If the zeros are leading zeros, this will make the contract smaller and save gas
 [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install)
 
 ## Build
-`cargo build --release`
+
+```bash
+rustup update
+git clone https://github.com/jeffreyscholz/solidity-zero-finder-rust.git
+cd solidity-zero-finder-rust
+cargo clean
+cargo build --release
+```
 
 ## Run
 `./target/release/eth-zero-finder "myFunctionName?(uint,address,...)" <num threads> (true|false)`


### PR DESCRIPTION
Found this repo through Rareskills, and wanted to test it out. Immediately ran into an issue where builds were failing (exact issue detailed in #3, and possibly fixes #2). Found this fix suggested in a completely unrelated repo issue thread (bytecodealliance/wasmtime#1758). Implementing this change did fix the issue, and builds are working (at least on an WSL env: 5.15.153.1-microsoft-standard-WSL2, Ubuntu 22.04.4 LTS)

Besides the above, the `Build` section has been updated to be more verbose.